### PR TITLE
Add automatic build testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name:
+    - name: Install MPI
+      run: sudo apt-get install -y libopenmpi-dev
+
+    - name: Build ALPS
       run: |
         make clean
         make all


### PR DESCRIPTION
This adds a GitHub actions run that builds ALPS. This will be run on every pull request to make sure the code can be compiled. When tests are set up, in a future pull request an extra step can be added under `steps:` to run the tests and check they work too.