### PR TITLE
ADS library auto update script

### DIFF
--- a/.github/scripts/add_alps_papers_to_ads_library.py
+++ b/.github/scripts/add_alps_papers_to_ads_library.py
@@ -1,0 +1,72 @@
+import os
+import json
+import requests
+
+BASE_URL = "https://api.adsabs.harvard.edu/v1"
+ALPS_ADS_BIB_CODE = "2018JPlPh..84d9003V"
+ADS_LIBRARY_ID = "vPWlMyiDRq-YfZ2bGDWS7Q"
+
+
+def query_response() -> requests.Response:
+    """Get a response by querying the ADS database for citations of the ALPS code"""
+    response = requests.get(
+        url=f"{BASE_URL}/search/query",
+        headers={"Authorization": f"Bearer {os.environ['ADS_API_TOKEN']}"},
+        params={
+            "q": f"citations(bibcode:{ALPS_ADS_BIB_CODE})",  # Query
+            "fl": "bibcode",  # Fields to return
+            "rows": 1000  # Max num results to return
+        }
+    )
+    return response
+
+
+def bibcodes_from_response(response: requests.Response) -> list:
+    """Given a requests response extract the bibcode unique identifiers"""
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to get: {response.url} content:\n{response.content}")
+
+    data = json.loads(response.content.decode())
+
+    try:
+        bibcodes = [item["bibcode"] for item in data["response"]["docs"]]
+        assert len(bibcodes) == data["response"]["numFound"]
+        print(f"Found {len(bibcodes)} papers citing {ALPS_ADS_BIB_CODE}")
+
+    except (KeyError, AssertionError) as e:
+        raise RuntimeError(f"Response from {response.url} was not valid") from e
+
+    return bibcodes
+
+
+def add_bibcodes_to_library(bibcodes: list, library_id: str) -> None:
+    """Add a list of papers to an ADS library"""
+
+    response = requests.post(
+        url=f"{BASE_URL}/biblib/documents/{library_id}",
+        headers={"Authorization": f"Bearer {os.environ['ADS_API_TOKEN']}"},
+        json={"bibcode": bibcodes, "action": "add"}
+    )
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to post {response.url} content:\n {response.content}")
+
+    data = json.loads(response.content.decode())
+    print(f"Added {data['number_added']} papers to library (id: {library_id})")
+    return None
+
+
+def main() -> None:
+
+    if "ADS_API_TOKEN" not in os.environ:
+        raise RuntimeError("Please set ADS_API_TOKEN as an environment variable")
+
+    add_bibcodes_to_library(
+        bibcodes=bibcodes_from_response(query_response()),
+        library_id=ADS_LIBRARY_ID
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/update_ads_library.yml
+++ b/.github/workflows/update_ads_library.yml
@@ -1,0 +1,31 @@
+---
+name: Update ADS library with papers citing ALPS
+
+on:
+  schedule:
+    # Midnight on every Sunday
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  update_library:
+    name: Update library
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install script dependencies
+        run: |
+          pip install requests==2.31
+
+      - name: Run script
+        env:
+          ADS_API_TOKEN: ${{ secrets.ADS_API_TOKEN }}
+        run: |
+          python .github/scripts/add_alps_papers_to_ads_library.py


### PR DESCRIPTION
This PR adds a python script and GitHub actions workflow suitable to update the ALPS [ADS library](https://ui.adsabs.harvard.edu/user/libraries/vPWlMyiDRq-YfZ2bGDWS7Q) with papers citing the [ALPS paper](https://ui.adsabs.harvard.edu/abs/2018JPlPh..84d9003V/) every week. It will require adding a repository secret containing an API token with permissions to add documents to the library. 

Tested: https://github.com/t-young31/ads-api-search-and-add

To add the secret:
1. Generate an API token from https://ui.adsabs.harvard.edu/user/settings/token as a logged in user
2. (on this repoistory) `Settings` → `Secrets and variables` → `Actions` → `New repository secret`
3. Name: `ADS_API_TOKEN`  Secret: `<token value from step 1>`
