### PR TITLE
Fix doc for map/root outputs, log(abs(D)) column

### DIFF
--- a/output.md
+++ b/output.md
@@ -16,7 +16,7 @@ This file is generated from the *map_search* subroutine in ALPS_fns.f90, and inv
 The data is ordered in columns as  
 1. $\omega_r$  
 2. $\gamma$   
-3. $|\mathcal{D}|$  
+3. $\log_{10} |\mathcal{D}|$  
 4. Re $[|\mathcal{D}|]$  
 5. Im $[|\mathcal{D}|]$  
 
@@ -32,7 +32,7 @@ The data is ordered as
 1. Solution number
 2. $\omega_r$  
 3. $\gamma$   
-4. $|\mathcal{D}|$  
+4. $\log_{10} |\mathcal{D}|$  
 5. Re $[|\mathcal{D}|]$  
 6. Im $[|\mathcal{D}|]$  
 


### PR DESCRIPTION
After going through the ALPS tutorial and looking at the outputs, it seems like the column abs(D) is reported out as log10(abs(D)) in both the `*.map` and `*.root` files, which may also be checked in `refine_guess` (line 2870) and `map_search` (line 2759).  This PR assumes that log10(abs(D)) is the desired output, as compared to updating the code to output abs(D) instead of log10(abs(D)), but if that is not the right approach please decline or let me know if I should do something else with the PR. Thanks!