### PR TITLE
Added config.h.in to the repository

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,25 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Name of package */
+#undef PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Version number of package */
+#undef VERSION


### PR DESCRIPTION
I have added the config.h.in file to the GitHub repository. It is usually ignored by our .gitignore, so we may need to modify this too. It should help when running ./configure (see Issue #223)