### PR TITLE
Correct missed factor of 2 when forcing the GLLS fit to be complex

### DIFF
--- a/src/ALPS_analyt.f90
+++ b/src/ALPS_analyt.f90
@@ -321,7 +321,7 @@ double complex function fit_function_poly(is,iperp,ppar_val,n_poly,fit_coeffs)
     poly_basis(n)=ppar_val_tmp
     fit_function_poly=fit_function_poly+fit_coeffs(n)*poly_basis(n)
     do n=2,n_poly
-       poly_basis(n) = cmplx(1.d0,0.d0,kind(1.d0)) * ppar_val_tmp * poly_basis(n-1) - poly_basis(n-2)
+       poly_basis(n) = cmplx(2.d0,0.d0,kind(1.d0)) * ppar_val_tmp * poly_basis(n-1) - poly_basis(n-2)
        fit_function_poly=fit_function_poly+fit_coeffs(n)*poly_basis(n)
     enddo
     if (logfit(is)) then


### PR DESCRIPTION
This was a recent error, that explains the 'bad' GLLS fits we saw at the last hackathon.
