### PR TITLE
lapack patches & changes for intel compiler

### DIFF
--- a/distribution/Makefile.in
+++ b/distribution/Makefile.in
@@ -252,7 +252,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AM_FCFLAGS = -O4 -fcheck=all -fbacktrace -fbounds-check -ffpe-trap=zero,overflow -Wconversion -Wsurprising -ffixed-line-length-none -ffree-line-length-none -Wunused -g -fbacktrace -I../src
-generate_distribution_LDADD = -lm -llapack -lblas
+generate_distribution_LDADD = ${LAPACK_LIBS} -lm
 generate_distribution_SOURCES = distribution_analyt.f90 generate_distribution.f90
 all: all-am
 

--- a/distribution/generate_distribution.f90
+++ b/distribution/generate_distribution.f90
@@ -156,6 +156,9 @@ program generate_distribution
   character(500) :: runname
   !! String parameter for input file.
 
+  external dgama
+  double precision :: dgama
+
   pi = atan(1.d0)*4.d0
 
   call read_in_params

--- a/interpolation/Makefile.in
+++ b/interpolation/Makefile.in
@@ -251,7 +251,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AM_FCFLAGS = -O4 -fcheck=all -fbacktrace -fbounds-check -ffpe-trap=zero,overflow -Wconversion -Wsurprising -ffixed-line-length-none -ffree-line-length-none -Wunused -g -fbacktrace
-interpolation_LDADD = -lm -llapack -lblas
+interpolation_LDADD = ${LAPACK_LIBS} -lm
 interpolation_SOURCES = interpolation.f90
 all: all-am
 

--- a/src/ALPS_analyt.f90
+++ b/src/ALPS_analyt.f90
@@ -1196,6 +1196,9 @@ subroutine determine_JT(is,n_params,nJT,JT,params,iperp,upper_limit,ipparbar_low
 	integer, intent(in) :: nJT
 	!! First dimension of matrix JT.
 
+	integer, intent(in) :: upper_limit
+	!! Upper limit of iperp space (relativistic and non-relativistic).
+
 	double precision, intent(out) :: JT(nJT,0:upper_limit)
 	!! Transposed Jacobian matrix of the fit function.
 
@@ -1204,9 +1207,6 @@ subroutine determine_JT(is,n_params,nJT,JT,params,iperp,upper_limit,ipparbar_low
 
 	integer, intent(in) :: iperp
 	!! Index of perpendicular momentum at which JT is evaluated.
-
-	integer, intent(in) :: upper_limit
-	!! Upper limit of iperp space (relativistic and non-relativistic).
 
 	integer, intent(in) :: ipparbar_lower
 	!! Lower index of parallel momentum (relativistic).


### PR DESCRIPTION
1. you missed a couple of places where the lapack variable should be used
2. there are a couple of places that the intel compiler complains about. I suspect gcc extensions to the language.