### PR TITLE
updating secant method two to use a tolarence rather than a threshold…

### DIFF
--- a/input.md
+++ b/input.md
@@ -79,6 +79,9 @@ Size of bounding region for secant method.
 **`D_gap`**  
 Size of allowable difference between roots.
 
+**`D_tol`**  
+Tolerance for secant method = 1, rtsec.
+
 **`positions_principal`**  
 Number of parallel momentum steps distant from the resonant momentum
 included in the numerical calculation of Eqn 3.5, $M_{I}$.

--- a/output.md
+++ b/output.md
@@ -112,11 +112,11 @@ These calculations are accurate in weak damping limit $\gamma < \omega_{\textrm{
 
 
 The data is ordered as  
-1. $k_\perp d_{ref}$
+1. $k_\perp d_{ref}$ 
 2. $k_\parallel d_{ref}$  
 3. $\omega_{\textrm{r}}/\Omega_{ref}$   
 4. $\gamma/\Omega_{ref}$   
-5. [+4(is-1)] $\gamma_{is}^{TTD}/\omega_{\textrm{r}}$
-6. [+4(is-1)] $\gamma_{is}^{LD}/\omega_{\textrm{r}}$
-7. [+4(is-1)] $\gamma_{is}^{n=+1}/\omega_{\textrm{r}}$
-8. [+4(is-1)] $\gamma_{is}^{n=-1}/\omega_{\textrm{r}}$
+5. [+4(is-1)] $\gamma_{is}^{TTD}/\omega_{\textrm{r}}$ 
+6. [+4(is-1)] $\gamma_{is}^{LD}/\omega_{\textrm{r}}$ 
+7. [+4(is-1)] $\gamma_{is}^{n=+1}/\omega_{\textrm{r}}$ 
+8. [+4(is-1)] $\gamma_{is}^{n=-1}/\omega_{\textrm{r}}$ 

--- a/src/ALPS.f90
+++ b/src/ALPS.f90
@@ -112,7 +112,7 @@ program alps
           write(*,'(a)') 'Starting Secant Method'
      call refine_guess !alps_fns
   endif
-
+  
   if (n_scan.gt.0) then !setting n_scan=0 turns off wavevector scanning
      select case (scan_option)
      case (1)

--- a/src/ALPS_com.f90
+++ b/src/ALPS_com.f90
@@ -31,7 +31,7 @@ contains
     use alps_var, only : writeOut, nperp, npar, nmax, nlim, nspec, numroots, ngamma,npparbar
     use alps_var, only : ns, qs, ms, wroots, kperp, kpar, bessel_zero
     use alps_var, only : wave, chi0, chi0_low, pp, df0, vA, pi
-    use alps_var, only : secant_method, numiter, D_threshold, D_gap, D_prec
+    use alps_var, only : secant_method, numiter, D_threshold, D_gap, D_prec, D_tol
     use alps_var, only : use_map, kperp_norm
     use alps_var, only : ni, nr, omi, omf, gami, gamf, loggridg, loggridw
     use alps_var, only : determine_minima, n_resonance_interval, positions_principal, Tlim
@@ -63,6 +63,7 @@ contains
     call mpi_bcast(D_threshold,1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierror)
     call mpi_bcast(D_prec,1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierror)
     call mpi_bcast(D_gap,1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierror)
+    call mpi_bcast(D_tol,1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierror)
     call mpi_bcast(Tlim,       1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierror)
     call mpi_bcast(use_map, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
     call mpi_bcast(kperp_norm, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)

--- a/src/ALPS_io.f90
+++ b/src/ALPS_io.f90
@@ -50,7 +50,8 @@ contains
     use alps_var, only : kperp_last, kpar_last, kperp_0, kpar_0
     use alps_var, only : use_map, writeOut, wroots, nspec, numroots, kperp_norm
     use alps_var, only : nperp, npar, arrayName, fit_check, param_fit, fit_type, perp_correction
-    use alps_var, only : ns, qs, ms, vA, Bessel_zero, numiter, D_threshold,positions_principal
+    use alps_var, only : ns, qs, ms, vA, Bessel_zero, numiter
+    use alps_var, only : D_threshold, D_tol, positions_principal
     use alps_var, only : determine_minima, n_resonance_interval, ngamma, npparbar, Tlim
     use alps_var, only : scan_option, n_scan, scan, relativistic, logfit, usebM
     use alps_var, only : maxsteps_fit, n_fits, lambda_initial_fit, lambdafac_fit, epsilon_fit
@@ -79,7 +80,7 @@ contains
          kperp, kpar, nspec, nroots, use_map, writeOut,&
          nperp, npar, ngamma, npparbar, vA, arrayName, Bessel_zero, &
          secant_method, numiter, kperp_norm, D_threshold, &
-         D_prec, D_gap, positions_principal, Tlim, &
+         D_prec, D_gap, D_tol, positions_principal, Tlim, &
          maxsteps_fit, lambda_initial_fit, lambdafac_fit, epsilon_fit, fit_check, &
          determine_minima, n_resonance_interval, scan_option, n_scan
 

--- a/src/ALPS_var.f90
+++ b/src/ALPS_var.f90
@@ -162,6 +162,9 @@ module alps_var
   double precision :: D_gap =1.d-5
   !! Size of allowable difference between roots.
 
+  double precision :: D_tol=1.d-7
+  !! Tolerance for secant method=1, [[alps_fn(module):rtsec(subroutine)]]
+  
   double precision :: pi
   !! The ratio of a circle's circumference to its diameter.
 
@@ -405,7 +408,8 @@ module alps_var
   public :: loggridw, loggridg, omi, omf, gami, gamf
   public :: arrayName, nperp, npar, f0, pp, df0, bessel_array
   public :: current_int, density_int
-  public :: nmax, nlim, wave, numiter, D_threshold, D_prec, D_gap, chi0, chi0_low
+  public :: nmax, nlim, wave, numiter, chi0, chi0_low
+  public :: D_threshold, D_prec, D_gap, D_tol
   public :: ns, qs, ms, vA, pi, Bessel_zero,sproc
   public :: ni, nr, positions_principal, Tlim
   public :: n_fits, maxsteps_fit,  lambda_initial_fit, lambdafac_fit, epsilon_fit

--- a/tests/test_ICW.in
+++ b/tests/test_ICW.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap = 1.d-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_analytical.in
+++ b/tests/test_analytical.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.D-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_bimax.in
+++ b/tests/test_bimax.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.d-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_chebyshev.in
+++ b/tests/test_chebyshev.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.d-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_cold_plasma.in
+++ b/tests/test_cold_plasma.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.d-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_double_scan.in
+++ b/tests/test_double_scan.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.D-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_electron_mode.in
+++ b/tests/test_electron_mode.in
@@ -48,6 +48,8 @@ D_threshold=1.d-20
 D_prec=1.d-5
 !Size of allowable gap between solutions
 D_gap=1.d-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_kpar_fast.in
+++ b/tests/test_kpar_fast.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-15
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.D-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_kperp.in
+++ b/tests/test_kperp.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.D-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_kperp_alpha.in
+++ b/tests/test_kperp_alpha.in
@@ -47,6 +47,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.D-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_map.in
+++ b/tests/test_map.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.D-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=3
 !# steps to integrate around resonance

--- a/tests/test_relativistic.in
+++ b/tests/test_relativistic.in
@@ -49,6 +49,8 @@ D_threshold = 1.d-30
 D_prec = 1.d-5
 !Size of allowable gap between solutions
 D_gap=1.d-5
+!Tolerance for secant method=1, rtsec
+D_tol=1.D-7
 !# points in principal value integral (see documentation)
 positions_principal=5
 !# steps to integrate around resonance


### PR DESCRIPTION
… value. Results in significant speed ups.

Using the NHDS module, compared the three methods:
4 species, pure bi-max kpar scan (6 procs)

-=-=-=-=-=-=
Method 0: (old secant; directly incorporated from NHDS)

running time: 3:25

Starting ALPS===================================
Time:
2025-09-22 -- 14:58:11

Finishing ALPS===================================
Time:
2025-09-22 -- 15:01:36

-=-=-=-=-=-=
Method 1: (rtsec with tolerance in difference between steps in the secant search. Rather than threshold value for |D|; given that |D| changes with varying |k|, this will require many fewer function evaluations.)

running time: 1:18

Starting ALPS===================================
Time:
2025-09-22 -- 14:48:11

Finishing ALPS===================================
Time:
2025-09-22 -- 14:49:29

-=-=-=-=-=-=
Method 2: (new secant; intended to be faster, clearly isn't for this case.)

running time: 8:45

Starting ALPS===================================
Time:
2025-09-22 -- 15:01:36

Finishing ALPS===================================
Time:
2025-09-22 -- 15:10:15 

The resulting dispersion relations are qualitatively the same for the Alfven solution from kpar dp=0.001 to 10.

If this looks good, I will update the test files to use the rtsec (secant method=1) option as the default.