### PR TITLE
Update add_alps_papers_to_ads_library.py

### DIFF
--- a/.github/scripts/add_alps_papers_to_ads_library.py
+++ b/.github/scripts/add_alps_papers_to_ads_library.py
@@ -40,7 +40,7 @@ def bibcodes_from_response(response: requests.Response) -> list:
     try:
         bibcodes = [item["bibcode"] for item in data["response"]["docs"]]
         assert len(bibcodes) == data["response"]["numFound"]
-        print(f"Found {len(bibcodes)} papers citing {ALPS_ADS_BIB_CODE}")
+        print(f"Found {len(bibcodes)} papers citing {ALPS_ADS_BIB_CODES}")
 
     except (KeyError, AssertionError) as e:
         raise RuntimeError(f"Response from {response.url} was not valid") from e


### PR DESCRIPTION
Another typo found in the output message referencing the bib code numbers (ALPS_ADS_BIB_CODES vs ALPS_ADS_BIB_CODE). Now fixed.